### PR TITLE
update the grad_cam to return gradient masks similar to other methods

### DIFF
--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -37,6 +37,8 @@ class GradCAM:
             layer_name (str): Targeted layer for GradCAM
             class_index (int): Index of targeted class
             colormap (int): OpenCV Colormap to use for heatmap visualization
+            image_weight (float): An optional `float` value in range [0,1] indicating the weight of
+                the input image to be overlaying the calculated attribution maps. Defaults to `0.7`.
 
         Returns:
             numpy.ndarray: Grid of all the GradCAM

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -50,7 +50,8 @@ class GradCAM:
 
         heatmaps = np.array(
             [
-                heatmap_display(cam.numpy(), image, colormap)
+                # not showing the actual image if image_weight=0
+                heatmap_display(cam.numpy(), image, colormap, image_weight=0)
                 for cam, image in zip(cams, images)
             ]
         )

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -25,6 +25,7 @@ class GradCAM:
         layer_name,
         class_index,
         colormap=cv2.COLORMAP_VIRIDIS,
+        image_weight=0.7,
     ):
         """
         Compute GradCAM for a specific class index.
@@ -51,7 +52,7 @@ class GradCAM:
         heatmaps = np.array(
             [
                 # not showing the actual image if image_weight=0
-                heatmap_display(cam.numpy(), image, colormap, image_weight=0)
+                heatmap_display(cam.numpy(), image, colormap, image_weight)
                 for cam, image in zip(cams, images)
             ]
         )

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -99,6 +99,8 @@ def heatmap_display(
         heatmap (numpy.ndarray): Array corresponding to the heatmap
         original_image (numpy.ndarray): Image on which we apply the heatmap
         colormap (int): OpenCV Colormap to use for heatmap visualization
+        image_weight (float): An optional `float` value in range [0,1] indicating the weight of
+            the input image to be overlaying the calculated attribution maps. Defaults to `0.7`
 
     Returns:
         np.ndarray: Original image with heatmap applied

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -45,7 +45,7 @@ def grid_display(array, num_rows=None, num_columns=None):
     grid = np.concatenate(
         [
             np.concatenate(
-                array[index * num_columns : (index + 1) * num_columns], axis=1
+                array[index * num_columns: (index + 1) * num_columns], axis=1
             )
             for index in range(num_rows)
         ],
@@ -89,7 +89,7 @@ def image_to_uint_255(image):
     return (image * 255).astype("uint8")
 
 
-def heatmap_display(heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS):
+def heatmap_display(heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS, image_weight=0.7):
     """
     Apply a heatmap (as an np.ndarray) on top of an original image.
 
@@ -111,6 +111,6 @@ def heatmap_display(heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS):
         cv2.cvtColor((heatmap * 255).astype("uint8"), cv2.COLOR_GRAY2BGR), colormap
     )
 
-    output = cv2.addWeighted(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), 0.7, heatmap, 1, 0)
+    output = cv2.addWeighted(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0)
 
     return cv2.cvtColor(output, cv2.COLOR_BGR2RGB)

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -45,7 +45,7 @@ def grid_display(array, num_rows=None, num_columns=None):
     grid = np.concatenate(
         [
             np.concatenate(
-                array[index * num_columns: (index + 1) * num_columns], axis=1
+                array[index * num_columns : (index + 1) * num_columns], axis=1
             )
             for index in range(num_rows)
         ],
@@ -89,7 +89,9 @@ def image_to_uint_255(image):
     return (image * 255).astype("uint8")
 
 
-def heatmap_display(heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS, image_weight=0.7):
+def heatmap_display(
+    heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS, image_weight=0.7
+):
     """
     Apply a heatmap (as an np.ndarray) on top of an original image.
 
@@ -111,6 +113,8 @@ def heatmap_display(heatmap, original_image, colormap=cv2.COLORMAP_VIRIDIS, imag
         cv2.cvtColor((heatmap * 255).astype("uint8"), cv2.COLOR_GRAY2BGR), colormap
     )
 
-    output = cv2.addWeighted(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0)
+    output = cv2.addWeighted(
+        cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0
+    )
 
     return cv2.cvtColor(output, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
Current implementation of gradcam returns the image overlayed by gradient mask and not following the same structure as the other methods (e.g. smooth_grad or intergrated_grad) in which the actual gradient masks are created as the output. 
As such, to keep it all following the same standard and usable in the same manner, I have adapted the grad_cam function so that the output is the gradient mask if the weight is set to 0. If one desires to have it as the current implementation, the weight value can be set to 0.7 as before.