### PR TITLE
Bug fix: Switched dimensions

### DIFF
--- a/tf_explain/core/occlusion_sensitivity.py
+++ b/tf_explain/core/occlusion_sensitivity.py
@@ -89,8 +89,8 @@ class OcclusionSensitivity:
 
         coordinates = [
             (index_y, index_x)
-            for index_x in range(sensitivity_map.shape[1])
-            for index_y in range(sensitivity_map.shape[0])
+            for index_x in range(sensitivity_map.shape[1]) # pylint: disable=unsubscriptable-object
+            for index_y in range(sensitivity_map.shape[0]) # pylint: disable=unsubscriptable-object
         ]
 
         predictions = model.predict(np.array(patches), batch_size=self.batch_size)

--- a/tf_explain/core/occlusion_sensitivity.py
+++ b/tf_explain/core/occlusion_sensitivity.py
@@ -89,8 +89,8 @@ class OcclusionSensitivity:
 
         coordinates = [
             (index_y, index_x)
-            for index_x, _ in enumerate(range(0, image.shape[0], patch_size))
-            for index_y, _ in enumerate(range(0, image.shape[1], patch_size))
+            for index_x in range(sensitivity_map.shape[1])
+            for index_y in range(sensitivity_map.shape[0])
         ]
 
         predictions = model.predict(np.array(patches), batch_size=self.batch_size)

--- a/tf_explain/core/occlusion_sensitivity.py
+++ b/tf_explain/core/occlusion_sensitivity.py
@@ -89,8 +89,12 @@ class OcclusionSensitivity:
 
         coordinates = [
             (index_y, index_x)
-            for index_x in range(sensitivity_map.shape[1]) # pylint: disable=unsubscriptable-object
-            for index_y in range(sensitivity_map.shape[0]) # pylint: disable=unsubscriptable-object
+            for index_x in range(
+                sensitivity_map.shape[1]  # pylint: disable=unsubscriptable-object
+            )
+            for index_y in range(
+                sensitivity_map.shape[0]  # pylint: disable=unsubscriptable-object
+            )
         ]
 
         predictions = model.predict(np.array(patches), batch_size=self.batch_size)

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -105,8 +105,7 @@ def heatmap_display(
     Returns:
         np.ndarray: Original image with heatmap applied
     """
-    heatmap = cv2.resize(heatmap, (original_image.shape[1],
-                                   original_image.shape[0]))
+    heatmap = cv2.resize(heatmap, (original_image.shape[1], original_image.shape[0]))
 
     image = image_to_uint_255(original_image)
 
@@ -116,6 +115,8 @@ def heatmap_display(
         cv2.cvtColor((heatmap * 255).astype("uint8"), cv2.COLOR_GRAY2BGR), colormap
     )
 
-    output = cv2.addWeighted(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0)
+    output = cv2.addWeighted(
+        cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0
+    )
 
     return cv2.cvtColor(output, cv2.COLOR_BGR2RGB)

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -105,7 +105,8 @@ def heatmap_display(
     Returns:
         np.ndarray: Original image with heatmap applied
     """
-    heatmap = cv2.resize(heatmap, original_image.shape[0:2])
+    heatmap = cv2.resize(heatmap, (original_image.shape[1],
+                                   original_image.shape[0]))
 
     image = image_to_uint_255(original_image)
 
@@ -115,8 +116,6 @@ def heatmap_display(
         cv2.cvtColor((heatmap * 255).astype("uint8"), cv2.COLOR_GRAY2BGR), colormap
     )
 
-    output = cv2.addWeighted(
-        cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0
-    )
+    output = cv2.addWeighted(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), image_weight, heatmap, 1, 0)
 
     return cv2.cvtColor(output, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
Working with non-square images, I found a bug in two places that switched the dimensions of the height and width axes. I changed this to the correct shape dimensions.

[x] Run tests using tox
[x] Format using black