### PR TITLE
Add option to use raw gradients instead of guided gradients on GradCam

### DIFF
--- a/tests/callbacks/test_grad_cam.py
+++ b/tests/callbacks/test_grad_cam.py
@@ -18,13 +18,17 @@ def test_should_call_grad_cam_callback(
             class_index=0,
             layer_name="activation_1",
             output_dir=output_dir,
-            use_guided_grads=True
+            use_guided_grads=True,
         )
     ]
 
     convolutional_model.fit(images, labels, batch_size=2, epochs=1, callbacks=callbacks)
 
     mock_explainer.explain.assert_called_once_with(
-        random_data, convolutional_model, class_index=0, layer_name="activation_1",use_guided_grads=True
+        random_data,
+        convolutional_model,
+        class_index=0,
+        layer_name="activation_1",
+        use_guided_grads=True,
     )
     assert len([_ for _ in output_dir.iterdir()]) == 1

--- a/tests/callbacks/test_grad_cam.py
+++ b/tests/callbacks/test_grad_cam.py
@@ -18,12 +18,13 @@ def test_should_call_grad_cam_callback(
             class_index=0,
             layer_name="activation_1",
             output_dir=output_dir,
+            use_guided_grads=True
         )
     ]
 
     convolutional_model.fit(images, labels, batch_size=2, epochs=1, callbacks=callbacks)
 
     mock_explainer.explain.assert_called_once_with(
-        random_data, convolutional_model, class_index=0, layer_name="activation_1"
+        random_data, convolutional_model, class_index=0, layer_name="activation_1",use_guided_grads=True
     )
     assert len([_ for _ in output_dir.iterdir()]) == 1

--- a/tests/core/test_grad_cam.py
+++ b/tests/core/test_grad_cam.py
@@ -42,8 +42,9 @@ def test_should_ponderate_output():
 def test_should_produce_gradients_and_filters(convolutional_model, random_data):
     images, _ = random_data
     layer_name = "activation_1"
+    use_guided_grads=True
     output, grads = GradCAM.get_gradients_and_filters(
-        convolutional_model, images, layer_name, 0
+        convolutional_model, images, layer_name, 0, use_guided_grads
     )
 
     assert output.shape == [len(images)] + list(
@@ -79,6 +80,7 @@ def test_should_explain_output(mocker):
         mocker.sentinel.model,
         mocker.sentinel.class_index,
         mocker.sentinel.layer_name,
+        mocker.sentinel.use_guided_grads
     )
 
     for heatmap, expected_heatmap in zip(
@@ -91,6 +93,7 @@ def test_should_explain_output(mocker):
         [mocker.sentinel.image_1, mocker.sentinel.image_2],
         mocker.sentinel.layer_name,
         mocker.sentinel.class_index,
+        True
     )
     mock_generate_output.assert_called_once_with(
         [mocker.sentinel.conv_output_1, mocker.sentinel.conv_output_2],

--- a/tests/core/test_grad_cam.py
+++ b/tests/core/test_grad_cam.py
@@ -42,7 +42,7 @@ def test_should_ponderate_output():
 def test_should_produce_gradients_and_filters(convolutional_model, random_data):
     images, _ = random_data
     layer_name = "activation_1"
-    use_guided_grads=True
+    use_guided_grads = True
     output, grads = GradCAM.get_gradients_and_filters(
         convolutional_model, images, layer_name, 0, use_guided_grads
     )
@@ -80,7 +80,7 @@ def test_should_explain_output(mocker):
         mocker.sentinel.model,
         mocker.sentinel.class_index,
         mocker.sentinel.layer_name,
-        mocker.sentinel.use_guided_grads
+        mocker.sentinel.use_guided_grads,
     )
 
     for heatmap, expected_heatmap in zip(
@@ -93,7 +93,7 @@ def test_should_explain_output(mocker):
         [mocker.sentinel.image_1, mocker.sentinel.image_2],
         mocker.sentinel.layer_name,
         mocker.sentinel.class_index,
-        True
+        True,
     )
     mock_generate_output.assert_called_once_with(
         [mocker.sentinel.conv_output_1, mocker.sentinel.conv_output_2],

--- a/tests/core/test_grad_cam.py
+++ b/tests/core/test_grad_cam.py
@@ -93,8 +93,9 @@ def test_should_explain_output(mocker):
         [mocker.sentinel.image_1, mocker.sentinel.image_2],
         mocker.sentinel.layer_name,
         mocker.sentinel.class_index,
-        True,
+        mocker.sentinel.use_guided_grads,
     )
+
     mock_generate_output.assert_called_once_with(
         [mocker.sentinel.conv_output_1, mocker.sentinel.conv_output_2],
         [mocker.sentinel.guided_grads_1, mocker.sentinel.guided_grads_2],

--- a/tests/integration/test_keras_api.py
+++ b/tests/integration/test_keras_api.py
@@ -152,6 +152,7 @@ def test_all_keras_api(
             layer_name="grad_cam_target",
             class_index=target_class,
             output_dir=output_dir,
+            use_guided_grads=True
         ),
         tf_explain.callbacks.ActivationsVisualizationCallback(
             validation_data, "grad_cam_target", output_dir=output_dir

--- a/tests/integration/test_keras_api.py
+++ b/tests/integration/test_keras_api.py
@@ -152,7 +152,7 @@ def test_all_keras_api(
             layer_name="grad_cam_target",
             class_index=target_class,
             output_dir=output_dir,
-            use_guided_grads=True
+            use_guided_grads=True,
         ),
         tf_explain.callbacks.ActivationsVisualizationCallback(
             validation_data, "grad_cam_target", output_dir=output_dir

--- a/tf_explain/callbacks/grad_cam.py
+++ b/tf_explain/callbacks/grad_cam.py
@@ -62,7 +62,7 @@ class GradCAMCallback(Callback):
             self.model,
             class_index=self.class_index,
             layer_name=self.layer_name,
-            use_guided_grads=self.use_guided_grads
+            use_guided_grads=self.use_guided_grads,
         )
 
         # Using the file writer, log the reshaped image.

--- a/tf_explain/callbacks/grad_cam.py
+++ b/tf_explain/callbacks/grad_cam.py
@@ -26,6 +26,7 @@ class GradCAMCallback(Callback):
         class_index,
         layer_name=None,
         output_dir=Path("./logs/grad_cam"),
+        use_guided_grads=True,
     ):
         """
         Constructor.
@@ -42,6 +43,7 @@ class GradCAMCallback(Callback):
         self.layer_name = layer_name
         self.class_index = class_index
         self.output_dir = Path(output_dir) / datetime.now().strftime("%Y%m%d-%H%M%S.%f")
+        self.use_guided_grads = use_guided_grads
         Path.mkdir(Path(self.output_dir), parents=True, exist_ok=True)
 
         self.file_writer = tf.summary.create_file_writer(str(self.output_dir))
@@ -60,6 +62,7 @@ class GradCAMCallback(Callback):
             self.model,
             class_index=self.class_index,
             layer_name=self.layer_name,
+            use_guided_grads=self.use_guided_grads
         )
 
         # Using the file writer, log the reshaped image.

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -101,6 +101,7 @@ class GradCAM:
             images (numpy.ndarray): 4D-Tensor with shape (batch_size, H, W, 3)
             layer_name (str): Targeted layer for GradCAM
             class_index (int): Index of targeted class
+            use_guided_grads (boolean): Whether to use guided grads or raw gradients
 
         Returns:
             Tuple[tf.Tensor, tf.Tensor]: (Target layer outputs, Guided gradients)

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -26,7 +26,7 @@ class GradCAM:
         layer_name=None,
         colormap=cv2.COLORMAP_VIRIDIS,
         image_weight=0.7,
-        use_guided_grads=True
+        use_guided_grads=True,
     ):
         """
         Compute GradCAM for a specific class index.
@@ -92,7 +92,9 @@ class GradCAM:
 
     @staticmethod
     @tf.function
-    def get_gradients_and_filters(model, images, layer_name, class_index, use_guided_grads):
+    def get_gradients_and_filters(
+        model, images, layer_name, class_index, use_guided_grads
+    ):
         """
         Generate guided gradients and convolutional outputs with an inference.
 
@@ -118,8 +120,11 @@ class GradCAM:
         grads = tape.gradient(loss, conv_outputs)
 
         if use_guided_grads:
-            grads = (tf.cast(conv_outputs > 0, "float32") *
-                     tf.cast(grads > 0, "float32") * grads)
+            grads = (
+                tf.cast(conv_outputs > 0, "float32")
+                * tf.cast(grads > 0, "float32")
+                * grads
+            )
 
         return conv_outputs, grads
 

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -24,9 +24,9 @@ class GradCAM:
         model,
         class_index,
         layer_name=None,
+        use_guided_grads=True,
         colormap=cv2.COLORMAP_VIRIDIS,
         image_weight=0.7,
-        use_guided_grads=True,
     ):
         """
         Compute GradCAM for a specific class index.


### PR DESCRIPTION

The current GradCAM implementation uses guided grads to generate the heatmaps.

The purpose of this PR is to offer the option to apply the GradCAM according to the equation (11) from the paper [Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization](https://arxiv.org/pdf/1610.02391.pdf), thus using the raw gradients instead of the guided grads.
This would be done by the parameter `use_guided_grads`

```python
import tf_explain

gradcam = tf_explain.core.GradCAM()
grid_gradcam = gradcam.explain(
    validation_data=EVAL_DATA 
    model=MODEL, 
    class_index=CLASS_INDEX,
    layer_name=LAYER_NAME,
    colormap=COLOR_MAP,
    use_guided_grads=False) # <----

grid_guided_gradcam = gradcam.explain(
    validation_data=EVAL_DATA 
    model=MODEL, 
    class_index=CLASS_INDEX,
    layer_name=LAYER_NAME,
    colormap=COLOR_MAP,
    use_guided_grads=True) # <----

## Using Keras Callbacks

from tf_explain.callbacks.grad_cam import GradCAMCallback

callback_guided_gradcam= GradCAMCallback(
    validation_data=EVAL_DATA 
    class_index=CLASS_INDEX,
    layer_name=LAYER_NAME,
    colormap=COLOR_MAP,
    use_guided_grads=True) # <----

callback_gradcam = GradCAMCallback(
    validation_data=EVAL_DATA 
    class_index=CLASS_INDEX,
    layer_name=LAYER_NAME,
    colormap=COLOR_MAP,
    use_guided_grads=False) # <----
```

# Why such feature?

First, offer the users the possibility to choose what fits best for them.

Second, doing some research on a problem I'm working on my private studies, GradCAM without guided grads shows better results than with the original guided grads.

To exemplify how GradCAM performs better without guided grads, see this [Colab ](https://colab.research.google.com/drive/1oVB109cB-zaWeYj6X8g0CyHaYXzG3SEY)
where the dataset [Beans](https://www.tensorflow.org/datasets/catalog/beans) is used for image classification.

With Guided GradCAM the heatmap is messy (third heatmap)
![Guided GradCAM](https://i.imgur.com/qJeseTr.png)

However with GradCAM without guided gradients the heatmap looks better
![GradCAM](https://i.imgur.com/tv7Hjra.png)
