### PR TITLE
Accept opencv alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ to let you choose between full and standalone-CPU versions. Additionally to the 
 # For CPU or GPU
 pip install tensorflow==2.2.0
 ```
-Opencv is also a dependency to install it run
+Opencv is also a dependency. To install it, run:
 ```bash
 # For CPU or GPU
 pip install opencv-python

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ to let you choose between full and standalone-CPU versions. Additionally to the 
 # For CPU or GPU
 pip install tensorflow==2.2.0
 ```
+Opencv is also a dependency to install it run
+```bash
+# For CPU or GPU
+pip install opencv-python
+```
 
 ## Quickstart
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="raphaelm@sicara.com",
     url="https://github.com/sicara/tf-explain",
     license="MIT",
-    install_requires=["opencv-python>=4.1.0.25"],
+    install_requires=[],
     extras_require={
         "tests": [
             "black>=19.3b0",

--- a/tf_explain/__init__.py
+++ b/tf_explain/__init__.py
@@ -7,6 +7,19 @@ callbacks to ease neural network's understanding.
 
 __version__ = "0.2.1"
 
+try:
+    import cv2
+except:
+    raise ImportError(
+        "TF-explain requires Opencv. " "Install Opencv via `pip install opencv-python`"
+    ) from None
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "TF-explain requires TensorFlow 2.0 or higher. "
+        "Install TensorFlow via `pip install tensorflow`"
+    ) from None
 from . import core
 from . import callbacks
 from . import utils

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -1,9 +1,9 @@
 """
 Core Module for Grad CAM Algorithm
 """
-import cv2
 import numpy as np
 import tensorflow as tf
+import cv2
 
 from tf_explain.utils.display import grid_display, heatmap_display
 from tf_explain.utils.saver import save_rgb

--- a/tf_explain/core/occlusion_sensitivity.py
+++ b/tf_explain/core/occlusion_sensitivity.py
@@ -3,8 +3,8 @@ Core Module for Occlusion Sensitivity
 """
 import math
 
-import cv2
 import numpy as np
+import cv2
 
 from tf_explain.utils.display import grid_display, heatmap_display
 from tf_explain.utils.image import apply_grey_patch

--- a/tf_explain/utils/display.py
+++ b/tf_explain/utils/display.py
@@ -2,8 +2,8 @@
 import math
 import warnings
 
-import cv2
 import numpy as np
+import cv2
 
 
 def grid_display(array, num_rows=None, num_columns=None):

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,6 @@ deps =
     pytest-cov
     pytest-mock
 commands =
+    pip install opencv-python
     pip install {env:TF_PACKAGE:}=={env:TF_VERSION:}
     pytest tests/ -vv --cov-report term-missing --no-cov-on-fail --cov-fail-under 85 --cov=tf_explain/


### PR DESCRIPTION
A possible fix to  #142 :  remove tensorflow and opencv dependency from setuptools  but check for a valid version at import time and raise a helpful error:
 "TF-explain requires Opencv. Install Opencv via `pip install opencv-python`" 
"TF-explain requires TensorFlow 2.0 or higher. Install TensorFlow via `pip install tensorflow`"

Assuming most users would have a flavor of both installed this would avoid installing conflicting packages.
For beginners the error should quickly guide them to  the fix