### PR TITLE
rtd-api-fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -148,7 +148,7 @@ logging-modules=logging
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
+contextmanager-decorators=contextlib.contextmanager,tensorflow.python.util.tf_contextlib.contextmanager,tf_contextlib.contextmanager
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,13 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
+python:
+   version: 3.7
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+           - docs
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("./../.."))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -7,12 +7,24 @@ Installation
 
 tf-explain is available on Pypi as an alpha release. To install it:
 ::
+
     pip install tf-explain
 
 
-Tensorflow Compatibility
+Tensorflow Dependency
 ************************
 
-tf-explain is compatible with Tensorflow 2. Additionally to the previous install,
-run::
+tf-explain depends on Tensorflow 2 but does not enforce any particular flavor.
+If you do not already have it you can install it using :
+::
+
     pip install tensorflow==2.1.0
+
+Opencv Dependency
+************************
+
+tf-explain depends on OpenCV but does not enforce any particular flavor.
+If you do not already have it you can install it using :
+::
+
+    pip install opencv-python

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
             "tox>=3.13.2",
         ],
         "publish": ["bumpversion>=0.5.3", "twine>=1.13.0"],
-        "docs": ["sphinx>=2.1.2", "sphinx-rtd-theme>=0.4.3"],
+        "docs": ["sphinx>=2.1.2", "sphinx-rtd-theme>=0.4.3", "opencv-python", "tensorflow==2.1.0"],
     },
     packages=find_packages(),
     python_requires=">=3.6",

--- a/tf_explain/__init__.py
+++ b/tf_explain/__init__.py
@@ -9,7 +9,7 @@ __version__ = "0.2.1"
 
 try:
     import cv2
-except:
+except ImportError:
     raise ImportError(
         "TF-explain requires Opencv. " "Install Opencv via `pip install opencv-python`"
     ) from None
@@ -23,3 +23,5 @@ except ImportError:
 from . import core
 from . import callbacks
 from . import utils
+
+__all__ = ["cv2", "tf", "core", "callbacks", "utils"]

--- a/tf_explain/core/grad_cam.py
+++ b/tf_explain/core/grad_cam.py
@@ -135,6 +135,7 @@ class GradCAM:
 
         Inputs are the convolutional outputs (shape WxHxN) and gradients (shape WxHxN).
         From there:
+
             - we compute the spatial average of the gradients
             - we build a ponderated sum of the convolutional outputs based on those averaged weights
 

--- a/tf_explain/core/smoothgrad.py
+++ b/tf_explain/core/smoothgrad.py
@@ -85,7 +85,12 @@ class SmoothGrad:
         """
         num_classes = model.output.shape[1]
 
-        expected_output = tf.one_hot([class_index] * noisy_images.shape[0], num_classes)
+        expected_output = tf.one_hot(
+            [class_index] * noisy_images.shape[0],
+            num_classes,
+            on_value=None,
+            off_value=None,
+        )
 
         with tf.GradientTape() as tape:
             inputs = tf.cast(noisy_images, tf.float32)

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -58,7 +58,9 @@ class VanillaGradients:
         """
         num_classes = model.output.shape[1]
 
-        expected_output = tf.one_hot([class_index] * images.shape[0], num_classes)
+        expected_output = tf.one_hot(
+            [class_index] * images.shape[0], num_classes, on_value=None, off_value=None
+        )
 
         with tf.GradientTape() as tape:
             inputs = tf.cast(images, tf.float32)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py36,py37,py38
-
+[flake8]
+max-line-length = 100
+ignore=E203,W503
 [testenv]
 pip_version = pip
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
This is a fix to #84  :   
    - read the docs was crashing during API generation because the environment lacked tensorflow and opencv, fixed it by adding them to docs requirements (in setup) and making rtd install them along with tf_explain 
    - updated the docs to reflect the new soft opencv dependency
    - fixed minor linting issues
by the  way @RaphaelMeudec can you also close #142 since fix has been merged ?

- [x ] Added code is tested
- [ x] I've run Black and linter
