### PR TITLE
Use score instead of likelihood in Vanilla Gradients

### DIFF
--- a/tests/callbacks/test_vanilla_gradients.py
+++ b/tests/callbacks/test_vanilla_gradients.py
@@ -15,7 +15,7 @@ def test_should_call_vanilla_gradients_callback(
 
     mock_explainer = mocker.MagicMock(
         _get_score_model=mocker.MagicMock(return_value=score_model),
-        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28)))
+        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
     )
 
     vanilla_gradient_callback.explainer = mock_explainer
@@ -23,9 +23,11 @@ def test_should_call_vanilla_gradients_callback(
     callbacks = [vanilla_gradient_callback]
 
     convolutional_model.fit(images, labels, batch_size=2, epochs=1, callbacks=callbacks)
-    
+
     mock_explainer._get_score_model.assert_called_once()
-    mock_explainer._explain_score_model.assert_called_once_with(random_data, score_model, 0)
+    mock_explainer._explain_score_model.assert_called_once_with(
+        random_data, score_model, 0
+    )
     assert len(list(output_dir.iterdir())) == 1
 
 
@@ -47,7 +49,7 @@ def test_should_only_compute_score_model_once(
 
     mock_explainer = mocker.MagicMock(
         _get_score_model=mocker.MagicMock(return_value=score_model),
-        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28)))
+        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
     )
 
     vanilla_gradient_callback.explainer = mock_explainer
@@ -56,6 +58,6 @@ def test_should_only_compute_score_model_once(
 
     # Two epochs
     convolutional_model.fit(images, labels, batch_size=2, epochs=2, callbacks=callbacks)
-    
+
     # Score model only computed once
     mock_explainer._get_score_model.assert_called_once()

--- a/tests/callbacks/test_vanilla_gradients.py
+++ b/tests/callbacks/test_vanilla_gradients.py
@@ -7,13 +7,15 @@ def test_should_call_vanilla_gradients_callback(
     random_data, convolutional_model, output_dir, mocker
 ):
     images, labels = random_data
+    score_model = convolutional_model
 
     vanilla_gradient_callback = VanillaGradientsCallback(
         validation_data=random_data, class_index=0, output_dir=output_dir
     )
 
     mock_explainer = mocker.MagicMock(
-        explain=mocker.MagicMock(return_value=np.zeros((28, 28)))
+        _get_score_model=mocker.MagicMock(return_value=score_model),
+        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28)))
     )
 
     vanilla_gradient_callback.explainer = mock_explainer
@@ -21,6 +23,7 @@ def test_should_call_vanilla_gradients_callback(
     callbacks = [vanilla_gradient_callback]
 
     convolutional_model.fit(images, labels, batch_size=2, epochs=1, callbacks=callbacks)
-
-    mock_explainer.explain.assert_called_once_with(random_data, convolutional_model, 0)
+    
+    mock_explainer._get_score_model.assert_called_once()
+    mock_explainer._explain_score_model.assert_called_once_with(random_data, score_model, 0)
     assert len(list(output_dir.iterdir())) == 1

--- a/tests/callbacks/test_vanilla_gradients.py
+++ b/tests/callbacks/test_vanilla_gradients.py
@@ -27,3 +27,35 @@ def test_should_call_vanilla_gradients_callback(
     mock_explainer._get_score_model.assert_called_once()
     mock_explainer._explain_score_model.assert_called_once_with(random_data, score_model, 0)
     assert len(list(output_dir.iterdir())) == 1
+
+
+def test_should_only_compute_score_model_once(
+    random_data, convolutional_model, output_dir, mocker
+):
+    """
+    Tests that the Vanilla Gradients explainer only computes the score model once
+    during training. This improves performance as it ensures the gradients are
+    always calculated with the same score model, which prevents tf.function retracing.
+    """
+
+    images, labels = random_data
+    score_model = convolutional_model
+
+    vanilla_gradient_callback = VanillaGradientsCallback(
+        validation_data=random_data, class_index=0, output_dir=output_dir
+    )
+
+    mock_explainer = mocker.MagicMock(
+        _get_score_model=mocker.MagicMock(return_value=score_model),
+        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28)))
+    )
+
+    vanilla_gradient_callback.explainer = mock_explainer
+
+    callbacks = [vanilla_gradient_callback]
+
+    # Two epochs
+    convolutional_model.fit(images, labels, batch_size=2, epochs=2, callbacks=callbacks)
+    
+    # Score model only computed once
+    mock_explainer._get_score_model.assert_called_once()

--- a/tests/callbacks/test_vanilla_gradients.py
+++ b/tests/callbacks/test_vanilla_gradients.py
@@ -14,8 +14,8 @@ def test_should_call_vanilla_gradients_callback(
     )
 
     mock_explainer = mocker.MagicMock(
-        _get_score_model=mocker.MagicMock(return_value=score_model),
-        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
+        get_score_model=mocker.MagicMock(return_value=score_model),
+        explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
     )
 
     vanilla_gradient_callback.explainer = mock_explainer
@@ -24,8 +24,8 @@ def test_should_call_vanilla_gradients_callback(
 
     convolutional_model.fit(images, labels, batch_size=2, epochs=1, callbacks=callbacks)
 
-    mock_explainer._get_score_model.assert_called_once()
-    mock_explainer._explain_score_model.assert_called_once_with(
+    mock_explainer.get_score_model.assert_called_once()
+    mock_explainer.explain_score_model.assert_called_once_with(
         random_data, score_model, 0
     )
     assert len(list(output_dir.iterdir())) == 1
@@ -48,8 +48,8 @@ def test_should_only_compute_score_model_once(
     )
 
     mock_explainer = mocker.MagicMock(
-        _get_score_model=mocker.MagicMock(return_value=score_model),
-        _explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
+        get_score_model=mocker.MagicMock(return_value=score_model),
+        explain_score_model=mocker.MagicMock(return_value=np.zeros((28, 28))),
     )
 
     vanilla_gradient_callback.explainer = mock_explainer
@@ -60,4 +60,4 @@ def test_should_only_compute_score_model_once(
     convolutional_model.fit(images, labels, batch_size=2, epochs=2, callbacks=callbacks)
 
     # Score model only computed once
-    mock_explainer._get_score_model.assert_called_once()
+    mock_explainer.get_score_model.assert_called_once()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,3 +55,52 @@ def convolutional_model(random_data):
     model.compile(optimizer="adam", loss="categorical_crossentropy")
 
     return model
+
+
+@pytest.fixture()
+def convolutional_model_for_vanilla_gradients(random_data):
+    x, y = random_data
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Conv2D(
+                16,
+                (3, 3),
+                activation=None,
+                name="conv_1",
+                input_shape=list(x.shape[1:]),
+            ),
+            tf.keras.layers.ReLU(name="activation_1"),
+            tf.keras.layers.Flatten(),
+            # Dense layer and Softmax are separate
+            tf.keras.layers.Dense(2),
+            tf.keras.layers.Softmax()
+        ]
+    )
+
+    model.compile(optimizer="adam", loss="categorical_crossentropy")
+
+    return model
+
+
+@pytest.fixture()
+def score_model_for_vanilla_gradients(random_data):
+    x, y = random_data
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Conv2D(
+                16,
+                (3, 3),
+                activation=None,
+                name="conv_1",
+                input_shape=list(x.shape[1:]),
+            ),
+            tf.keras.layers.ReLU(name="activation_1"),
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(2)
+            # No final Softmax layer
+        ]
+    )
+
+    model.compile(optimizer="adam", loss="categorical_crossentropy")
+
+    return model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def convolutional_model(random_data):
 
 
 @pytest.fixture()
-def convolutional_model_for_vanilla_gradients(random_data):
+def convolutional_model_with_separate_activation_layer(random_data):
     x, y = random_data
     model = tf.keras.Sequential(
         [
@@ -83,7 +83,7 @@ def convolutional_model_for_vanilla_gradients(random_data):
 
 
 @pytest.fixture()
-def score_model_for_vanilla_gradients(random_data):
+def convolutional_model_without_final_activation(random_data):
     x, y = random_data
     model = tf.keras.Sequential(
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def convolutional_model_for_vanilla_gradients(random_data):
             tf.keras.layers.Flatten(),
             # Dense layer and Softmax are separate
             tf.keras.layers.Dense(2),
-            tf.keras.layers.Softmax()
+            tf.keras.layers.Softmax(),
         ]
     )
 

--- a/tests/core/test_vanilla_gradients.py
+++ b/tests/core/test_vanilla_gradients.py
@@ -1,5 +1,8 @@
 import pytest
-from tf_explain.core.vanilla_gradients import VanillaGradients
+from tf_explain.core.vanilla_gradients import (
+    VanillaGradients,
+    UNSUPPORTED_ARCHITECTURE_WARNING,
+)
 
 
 def test_should_explain_output(
@@ -47,5 +50,5 @@ def test_get_score_model_returns_suitable_model(
 
 def test_get_score_model_logs_warnings_when_model_not_suitable(convolutional_model):
     explainer = VanillaGradients()
-    with pytest.warns(UserWarning, match=r"^Unsupported model architecture"):
+    with pytest.warns(UserWarning, match=UNSUPPORTED_ARCHITECTURE_WARNING):
         explainer.get_score_model(convolutional_model)

--- a/tests/core/test_vanilla_gradients.py
+++ b/tests/core/test_vanilla_gradients.py
@@ -3,7 +3,7 @@ from tf_explain.core.vanilla_gradients import VanillaGradients
 
 
 def test_should_explain_output(
-    convolutional_model_for_vanilla_gradients, random_data, mocker
+    convolutional_model_with_separate_activation_layer, random_data, mocker
 ):
     mocker.patch(
         "tf_explain.core.vanilla_gradients.grid_display", side_effect=lambda x: x
@@ -11,31 +11,35 @@ def test_should_explain_output(
     images, labels = random_data
     explainer = VanillaGradients()
     grid = explainer.explain(
-        (images, labels), convolutional_model_for_vanilla_gradients, 0
+        (images, labels), convolutional_model_with_separate_activation_layer, 0
     )
 
     # Outputs is in grayscale format
     assert grid.shape == images.shape[:-1]
 
 
-def test_get_averaged_gradients(random_data, score_model_for_vanilla_gradients):
+def test_get_averaged_gradients(
+    random_data, convolutional_model_without_final_activation
+):
     images, _ = random_data
     gradients = VanillaGradients.compute_gradients(
-        images, score_model_for_vanilla_gradients, 0
+        images, convolutional_model_without_final_activation, 0
     )
 
     assert gradients.shape == images.shape
 
 
 def test_get_score_model_returns_suitable_model(
-    convolutional_model_for_vanilla_gradients,
+    convolutional_model_with_separate_activation_layer,
 ):
     explainer = VanillaGradients()
     # The last two layers of the original model are a Dense layer with no activation (i.e. linear)
     # followed by a Softmax layer.
-    score_layer = convolutional_model_for_vanilla_gradients.layers[-2]
-    softmax_layer = convolutional_model_for_vanilla_gradients.layers[-1]
-    score_model = explainer.get_score_model(convolutional_model_for_vanilla_gradients)
+    score_layer = convolutional_model_with_separate_activation_layer.layers[-2]
+    softmax_layer = convolutional_model_with_separate_activation_layer.layers[-1]
+    score_model = explainer.get_score_model(
+        convolutional_model_with_separate_activation_layer
+    )
     # The score model should exclude the final activation layer.
     assert score_model.layers[-1] == score_layer
     assert softmax_layer not in score_model.layers

--- a/tests/core/test_vanilla_gradients.py
+++ b/tests/core/test_vanilla_gradients.py
@@ -1,5 +1,4 @@
 import pytest
-from tensorflow.keras.layers import Dense, Softmax
 from tf_explain.core.vanilla_gradients import VanillaGradients
 
 
@@ -36,7 +35,7 @@ def test_get_score_model_returns_suitable_model(
     # followed by a Softmax layer.
     score_layer = convolutional_model_for_vanilla_gradients.layers[-2]
     softmax_layer = convolutional_model_for_vanilla_gradients.layers[-1]
-    score_model = explainer._get_score_model(convolutional_model_for_vanilla_gradients)
+    score_model = explainer.get_score_model(convolutional_model_for_vanilla_gradients)
     # The score model should exclude the final activation layer.
     assert score_model.layers[-1] == score_layer
     assert softmax_layer not in score_model.layers
@@ -45,4 +44,4 @@ def test_get_score_model_returns_suitable_model(
 def test_get_score_model_logs_warnings_when_model_not_suitable(convolutional_model):
     explainer = VanillaGradients()
     with pytest.warns(UserWarning, match=r"^Unsupported model architecture"):
-        explainer._get_score_model(convolutional_model)
+        explainer.get_score_model(convolutional_model)

--- a/tests/core/test_vanilla_gradients.py
+++ b/tests/core/test_vanilla_gradients.py
@@ -1,20 +1,40 @@
+import pytest
+from tensorflow.keras.layers import Dense, Softmax
 from tf_explain.core.vanilla_gradients import VanillaGradients
 
 
-def test_should_explain_output(convolutional_model, random_data, mocker):
+def test_should_explain_output(convolutional_model_for_vanilla_gradients, random_data, mocker):
     mocker.patch(
         "tf_explain.core.vanilla_gradients.grid_display", side_effect=lambda x: x
     )
     images, labels = random_data
     explainer = VanillaGradients()
-    grid = explainer.explain((images, labels), convolutional_model, 0)
+    grid = explainer.explain((images, labels), convolutional_model_for_vanilla_gradients, 0)
 
     # Outputs is in grayscale format
     assert grid.shape == images.shape[:-1]
 
 
-def test_get_averaged_gradients(random_data, convolutional_model):
+def test_get_averaged_gradients(random_data, score_model_for_vanilla_gradients):
     images, _ = random_data
-    gradients = VanillaGradients.compute_gradients(images, convolutional_model, 0)
+    gradients = VanillaGradients.compute_gradients(images, score_model_for_vanilla_gradients, 0)
 
     assert gradients.shape == images.shape
+
+
+def test_get_score_model_returns_suitable_model(convolutional_model_for_vanilla_gradients):
+    explainer = VanillaGradients()
+    # The last two layers of the original model are a Dense layer with no activation (i.e. linear)
+    # followed by a Softmax layer.
+    score_layer = convolutional_model_for_vanilla_gradients.layers[-2]
+    softmax_layer = convolutional_model_for_vanilla_gradients.layers[-1]
+    score_model = explainer._get_score_model(convolutional_model_for_vanilla_gradients)
+    # The score model should exclude the final activation layer.
+    assert score_model.layers[-1] == score_layer
+    assert softmax_layer not in score_model.layers
+
+
+def test_get_score_model_logs_warnings_when_model_not_suitable(convolutional_model):
+    explainer = VanillaGradients()
+    with pytest.warns(UserWarning, match=r"^Unsupported model architecture"):
+        explainer._get_score_model(convolutional_model)

--- a/tests/core/test_vanilla_gradients.py
+++ b/tests/core/test_vanilla_gradients.py
@@ -3,13 +3,17 @@ from tensorflow.keras.layers import Dense, Softmax
 from tf_explain.core.vanilla_gradients import VanillaGradients
 
 
-def test_should_explain_output(convolutional_model_for_vanilla_gradients, random_data, mocker):
+def test_should_explain_output(
+    convolutional_model_for_vanilla_gradients, random_data, mocker
+):
     mocker.patch(
         "tf_explain.core.vanilla_gradients.grid_display", side_effect=lambda x: x
     )
     images, labels = random_data
     explainer = VanillaGradients()
-    grid = explainer.explain((images, labels), convolutional_model_for_vanilla_gradients, 0)
+    grid = explainer.explain(
+        (images, labels), convolutional_model_for_vanilla_gradients, 0
+    )
 
     # Outputs is in grayscale format
     assert grid.shape == images.shape[:-1]
@@ -17,12 +21,16 @@ def test_should_explain_output(convolutional_model_for_vanilla_gradients, random
 
 def test_get_averaged_gradients(random_data, score_model_for_vanilla_gradients):
     images, _ = random_data
-    gradients = VanillaGradients.compute_gradients(images, score_model_for_vanilla_gradients, 0)
+    gradients = VanillaGradients.compute_gradients(
+        images, score_model_for_vanilla_gradients, 0
+    )
 
     assert gradients.shape == images.shape
 
 
-def test_get_score_model_returns_suitable_model(convolutional_model_for_vanilla_gradients):
+def test_get_score_model_returns_suitable_model(
+    convolutional_model_for_vanilla_gradients,
+):
     explainer = VanillaGradients()
     # The last two layers of the original model are a Dense layer with no activation (i.e. linear)
     # followed by a Softmax layer.

--- a/tf_explain/callbacks/vanilla_gradients.py
+++ b/tf_explain/callbacks/vanilla_gradients.py
@@ -42,10 +42,11 @@ class VanillaGradientsCallback(Callback):
         Path.mkdir(Path(self.output_dir), parents=True, exist_ok=True)
 
         self.file_writer = tf.summary.create_file_writer(str(self.output_dir))
+        self.score_model = None
 
     def set_model(self, model):
         super().set_model(model)
-        self.score_model = self.explainer._get_score_model(model)
+        self.score_model = self.explainer.get_score_model(model)
 
     def on_epoch_end(self, epoch, logs=None):
         """
@@ -55,7 +56,7 @@ class VanillaGradientsCallback(Callback):
             epoch (int): Epoch index
             logs (dict): Additional information on epoch
         """
-        grid = self.explainer._explain_score_model(
+        grid = self.explainer.explain_score_model(
             self.validation_data, self.score_model, self.class_index
         )
 

--- a/tf_explain/callbacks/vanilla_gradients.py
+++ b/tf_explain/callbacks/vanilla_gradients.py
@@ -43,6 +43,10 @@ class VanillaGradientsCallback(Callback):
 
         self.file_writer = tf.summary.create_file_writer(str(self.output_dir))
 
+    def set_model(self, model):
+        super().set_model(model)
+        self.score_model = self.explainer._get_score_model(model)
+
     def on_epoch_end(self, epoch, logs=None):
         """
         Draw VanillaGradients outputs at each epoch end to Tensorboard.
@@ -51,8 +55,8 @@ class VanillaGradientsCallback(Callback):
             epoch (int): Epoch index
             logs (dict): Additional information on epoch
         """
-        grid = self.explainer.explain(
-            self.validation_data, self.model, self.class_index
+        grid = self.explainer._explain_score_model(
+            self.validation_data, self.score_model, self.class_index
         )
 
         # Using the file writer, log the reshaped image.

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -20,7 +20,7 @@ _activation_layer_classes = (
     tf.keras.layers.PReLU,
     tf.keras.layers.ReLU,
     tf.keras.layers.Softmax,
-    tf.keras.layers.ThresholdedReLU
+    tf.keras.layers.ThresholdedReLU,
 )
 
 
@@ -127,7 +127,7 @@ class VanillaGradients:
             inputs = tf.cast(images, tf.float32)
             tape.watch(inputs)
             scores = model(inputs)
-            scores_for_class = scores[:, class_index:class_index+1]
+            scores_for_class = scores[:, class_index : class_index + 1]
 
         return tape.gradient(scores, inputs)
 

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -42,7 +42,9 @@ class VanillaGradients:
                 to perform the method on. Tuple containing (x, y).
             model (tf.keras.Model): tf.keras model to inspect. The last two layers of
                 the model should be: a layer which computes class scores with no
-                activation, followed by an activation layer.
+                activation, followed by an activation layer. This is to enable the
+                gradient calculation to bypass the final activation and calculate
+                the gradient of the score instead.
             class_index (int): Index of targeted class
 
         Returns:

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -73,7 +73,7 @@ class VanillaGradients:
         """
         activation_layer = model.layers[-1]
         if not self._is_activation_layer(activation_layer):
-            warn(_unsupported_architecture_warning, stacklevel=2)
+            warn(_unsupported_architecture_warning, stacklevel=3)
 
         output = activation_layer.input
 

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -127,7 +127,7 @@ class VanillaGradients:
             inputs = tf.cast(images, tf.float32)
             tape.watch(inputs)
             scores = model(inputs)
-            scores_for_class = scores[:, class_index : class_index + 1]
+            scores_for_class = scores[:, class_index]
 
         return tape.gradient(scores_for_class, inputs)
 

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -9,12 +9,13 @@ from tf_explain.utils.image import transform_to_normalized_grayscale
 from tf_explain.utils.saver import save_grayscale
 
 
-UNSUPPORTED_ARCHITECTURE_WARNING = "\
-Unsupported model architecture for VanillaGradients. The last two layers of \
-the model should be: a layer which computes class scores with no activation, \
-followed by an activation layer."
+UNSUPPORTED_ARCHITECTURE_WARNING = (
+    "Unsupported model architecture for VanillaGradients. The last two layers of "
+    "the model should be: a layer which computes class scores with no activation, "
+    "followed by an activation layer."
+)
 
-_activation_layer_classes = (
+ACTIVATION_LAYER_CLASSES = (
     tf.keras.layers.Activation,
     tf.keras.layers.LeakyReLU,
     tf.keras.layers.PReLU,
@@ -83,7 +84,7 @@ class VanillaGradients:
         Returns:
             Whether the layer is an activation layer
         """
-        return isinstance(layer, _activation_layer_classes)
+        return isinstance(layer, ACTIVATION_LAYER_CLASSES)
 
     def explain_score_model(self, validation_data, score_model, class_index):
         """

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -74,6 +74,7 @@ class VanillaGradients:
         activation_layer = model.layers[-1]
         if not self._is_activation_layer(activation_layer):
             warn(_unsupported_architecture_warning, stacklevel=3)
+            return model
 
         output = activation_layer.input
 

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -1,15 +1,15 @@
 """
 Core Module for Vanilla Gradients
 """
-import tensorflow as tf
 from warnings import warn
+import tensorflow as tf
 
 from tf_explain.utils.display import grid_display
 from tf_explain.utils.image import transform_to_normalized_grayscale
 from tf_explain.utils.saver import save_grayscale
 
 
-_unsupported_architecture_warning = "\
+UNSUPPORTED_ARCHITECTURE_WARNING = "\
 Unsupported model architecture for VanillaGradients. The last two layers of \
 the model should be: a layer which computes class scores with no activation, \
 followed by an activation layer."
@@ -48,10 +48,10 @@ class VanillaGradients:
         Returns:
             numpy.ndarray: Grid of all the gradients
         """
-        score_model = self._get_score_model(model)
-        return self._explain_score_model(validation_data, score_model, class_index)
+        score_model = self.get_score_model(model)
+        return self.explain_score_model(validation_data, score_model, class_index)
 
-    def _get_score_model(self, model):
+    def get_score_model(self, model):
         """
         Create a new model that excludes the final Softmax layer from the given model
 
@@ -63,7 +63,7 @@ class VanillaGradients:
         """
         activation_layer = model.layers[-1]
         if not self._is_activation_layer(activation_layer):
-            warn(_unsupported_architecture_warning, stacklevel=3)
+            warn(UNSUPPORTED_ARCHITECTURE_WARNING, stacklevel=3)
             return model
 
         output = activation_layer.input
@@ -83,7 +83,7 @@ class VanillaGradients:
         """
         return isinstance(layer, _activation_layer_classes)
 
-    def _explain_score_model(self, validation_data, score_model, class_index):
+    def explain_score_model(self, validation_data, score_model, class_index):
         """
         Perform gradients backpropagation for a given input
 
@@ -129,7 +129,7 @@ class VanillaGradients:
             scores = model(inputs)
             scores_for_class = scores[:, class_index : class_index + 1]
 
-        return tape.gradient(scores, inputs)
+        return tape.gradient(scores_for_class, inputs)
 
     def save(self, grid, output_dir, output_name):
         """

--- a/tf_explain/core/vanilla_gradients.py
+++ b/tf_explain/core/vanilla_gradients.py
@@ -61,8 +61,7 @@ class VanillaGradients:
 
         return grid
 
-    @staticmethod
-    def _get_score_model(model):
+    def _get_score_model(self, model):
         """
         Create a new model that excludes the final Softmax layer from the given model.
 
@@ -80,8 +79,7 @@ class VanillaGradients:
 
         return tf.keras.Model(inputs=model.inputs, outputs=output)
 
-    @staticmethod
-    def _is_activation_layer(layer):
+    def _is_activation_layer(self, layer):
         """
         Check whether the given layer is an activation layer.
 


### PR DESCRIPTION
Addresses #159 

I've modified VanillaGradients.explain so instead of using the full model, it first creates a "score model" - the same as the original model, except without the final activation layer - and uses that instead.

If callers supply a model where the last layer isn't an activation layer, a warning is generated, and we use the original model as the score model. This tends to produce uninteresting output, so it should be pretty clear to users that something has gone wrong in this case.

Calling VanillaGradients.explain directly from VanillaGradientsCallback caused tf.function rerouting because the score model was being regenerated on every epoch. This made Tensorflow generate lots of warning messages and presumably reduces performance (I think I did see a performance hit when I tried it locally). So, instead, I split VanillaGradientsCallback.explain into "get_score_model" and "explain_score_model". The idea is that get_score_model gets called only once by the callback, and explain_score_model gets called every epoch. This is possible because the base Callback class has a set_model method which gets called by the framework, and I added an override for it.

- [x] Added code is tested
- [x] I've run Black and linter
