### PR TITLE
Update integrated_gradients.py

### DIFF
--- a/tf_explain/core/integrated_gradients.py
+++ b/tf_explain/core/integrated_gradients.py
@@ -42,7 +42,7 @@ class IntegratedGradients:
         )
 
         grayscale_integrated_gradients = transform_to_normalized_grayscale(
-            tf.abs(integrated_gradients)
+            tf.abs(images*integrated_gradients)
         ).numpy()
 
         grid = grid_display(grayscale_integrated_gradients)


### PR DESCRIPTION
completion of the missing formulas   add  x-x'

transform_to_normalized_grayscale(tf.abs(integrated_gradients)) -> transform_to_normalized_grayscale(tf.abs(integrated_gradients*images))

After testing, the modified code could interpret the image's attribution normally